### PR TITLE
Remove macos and python>=3.8 from build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        os: [ubuntu-latest]
+        python-version: [3.7]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Remove macOS and python>=3.8 from GitHub Actions CI to reduce our minute usage. In the future, I will set up caching of dependencies to reduce this further.