### PR TITLE
Fix codecoverage action in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Upload coverage to Codecov
         # We don't want to push coverge for every job in the matrix.
         # Rather arbitrarily, choose to push on Ubuntu with Python 3.9.
-        if: matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest' && (github.event_name == 'push' || github.event_name == 'pull_request')
+        if: matrix.python-version == '3.7' && matrix.os == 'ubuntu-latest' && (github.event_name == 'push' || github.event_name == 'pull_request')
         uses: codecov/codecov-action@v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Coverage was only running for python3.9, which we removed. Run converge for python3.7 instead.